### PR TITLE
Preserve layer visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ overLayers: {
 
 // Transparent slide bar settings (true or false)
 opacityControl: true
+
+// Whether the current visibility state of the Operational layers should be preserved or not.
+// False by default.
+preserveLayerVisibility: true
 ```
 
 ### Example
@@ -180,6 +184,7 @@ map.on('load', function () {
         baseLayers: mapBaseLayer,
         overLayers: mapOverLayer,
         opacityControl: true,
+        preserveLayerVisibility: true,
     });
     map.addControl(Opacity, 'top-right');
 
@@ -384,6 +389,7 @@ map.on('load', function () {
         baseLayers: mapBaseLayer,
         overLayers: mapOverLayer,
         opacityControl: true,
+        preserveLayerVisibility: true,
     });
     map.addControl(Opacity, 'top-right');
 

--- a/example/index.ts
+++ b/example/index.ts
@@ -111,6 +111,7 @@ map.on('load', function () {
         baseLayers: mapBaseLayer,
         overLayers: mapOverLayer,
         opacityControl: true,
+        preserveLayerVisibility: true,
     });
     map.addControl(opacityControl, 'top-right');
 

--- a/src/maplibre-gl-opacity.ts
+++ b/src/maplibre-gl-opacity.ts
@@ -6,6 +6,7 @@ type OpacityControlOptions = {
     baseLayers: Record<string, string>;
     overLayers: Record<string, string>;
     opacityControl: boolean;
+    preserveLayerVisibility: boolean;
 };
 
 // デフォルトオプション設定
@@ -13,6 +14,7 @@ const defaultOptions: OpacityControlOptions = {
     baseLayers: {},
     overLayers: {},
     opacityControl: false,
+    preserveLayerVisibility: false,
 };
 
 class OpacityControl implements IControl {
@@ -21,12 +23,14 @@ class OpacityControl implements IControl {
     #baseLayersOption: Record<string, string>;
     #overLayersOption: Record<string, string>;
     #opacityControlOption: boolean;
+    #preserveLayerVisibility: boolean
 
     constructor(options: Partial<OpacityControlOptions>) {
         // オプション設定
         this.#baseLayersOption = options.baseLayers ?? defaultOptions.baseLayers;
         this.#overLayersOption = options.overLayers ?? defaultOptions.overLayers;
         this.#opacityControlOption = options.opacityControl ?? defaultOptions.opacityControl;
+        this.#preserveLayerVisibility = options.preserveLayerVisibility ?? defaultOptions.preserveLayerVisibility;
     }
 
     // ラジオボタン作成
@@ -74,8 +78,13 @@ class OpacityControl implements IControl {
         const checkBox = document.createElement('input');
         checkBox.setAttribute('type', 'checkbox');
         checkBox.id = layerId;
-        // 全レイヤ非表示
-        this.#map!.setLayoutProperty(layerId, 'visibility', 'none');
+        if(this.#preserveLayerVisibility){
+            // Get the current state & use it to set the state of Check box
+            checkBox.checked = this.#map.getLayoutProperty(layerId, 'visibility');
+        }else {
+            // 全レイヤ非表示
+            this.#map!.setLayoutProperty(layerId, 'visibility', 'none');
+        }
         this.#container!.appendChild(checkBox);
         // チェックボックスイベント
         checkBox.addEventListener('change', (event) => {


### PR DESCRIPTION
I wanted that the layer switcher should preserve the current visibility of the layers, and the layers need not be switched off when this control is used.
This has also been requested in #20 

I have added an option called `preserveLayerVisibility`.  When it set to 'true`, the control will read the current visibility state of each operational layer, and sets the checkbox accordingly.

This option *does not* affect how the control switches the base layers on and off.

This PR Fixes #20 
