### PR TITLE
Add name attribute for base layer radio buttons to improve a11y

### DIFF
--- a/src/maplibre-gl-opacity.ts
+++ b/src/maplibre-gl-opacity.ts
@@ -37,6 +37,7 @@ class OpacityControl implements IControl {
         const radioButton = document.createElement('input');
         radioButton.setAttribute('type', 'radio');
         radioButton.id = layerId;
+        radioButton.name = 'baseLayer';
         // 初期レイヤのみ表示
         if (layerId === initLayer) {
             radioButton.checked = true;


### PR DESCRIPTION
Base layer radio buttons don't have name attribute so a screen reader cannot recognize these buttons are the same group.